### PR TITLE
make space in path compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ MYMETA.yml
 Makefile
 Makefile.old
 /_Inline
+/_In line
 /blib
 /pm_to_blib

--- a/Filters.pm
+++ b/Filters.pm
@@ -129,7 +129,7 @@ sub Preprocess {
     open $CSRC, ">", $tmpfile or die $!;
     print $CSRC $code;
     close $CSRC;
-    open $PROCESSED, "$cpp $tmpfile |" or die $!;
+    open $PROCESSED, "$cpp \"$tmpfile\" |" or die $!;
     $code = join '', <$PROCESSED>;
     close $PROCESSED;
     unlink $tmpfile;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
     Inline    => 0.42,
     Inline::C => 0.76,
   },
-  clean => {FILES => '_Inline/'},
+  clean => {FILES => ['_Inline/', '"_In line/"']},
   ($ExtUtils::MakeMaker::VERSION gt '6.46' ?
    ('META_MERGE'  =>
     {

--- a/t/Preprocess_cppflags.t
+++ b/t/Preprocess_cppflags.t
@@ -2,10 +2,15 @@ use strict;
 use warnings;
 use diagnostics;
 use Config;
+BEGIN {
+    mkdir '_In line';
+}
 
 print "1..4\n";
 
+
 use Inline C => Config =>
+    DIRECTORY  => '_In line', #space in path test
     #BUILD_NOISY => 1,
     FORCE_BUILD => 1,
     CCFLAGS     => $Config{ccflags};


### PR DESCRIPTION
Inline::Filters passed an unquoted filepath to the CC of the location of
the .c file, if there is a space in the path, the CC can't find the file
and errors out. "C:\Documents and Settings\Owner.cpan\build" is a common
path on Win32 where things are built from with a space in the path, so
I::F was uninstallable using cpanm or cpan shell before this commit.
